### PR TITLE
Fix issue `use_type` with added firearms

### DIFF
--- a/react/AddFirearmControl.js
+++ b/react/AddFirearmControl.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {Grid, Col, Row, Label, Button} from 'react-bootstrap';
 
 import DropdownList from 'react-widgets/DropdownList';
+import WeaponRow from "./WeaponRow";
 
 var rest = require('./sheet-rest');
 
@@ -53,7 +54,8 @@ class AddFirearmControl extends React.Component {
         if (this.props.onFirearmAdd) {
             this.props.onFirearmAdd({
                 base: this.state.selectedFirearm,
-                ammo: this.state.selectedAmmo
+                ammo: this.state.selectedAmmo,
+                use_type: WeaponRow.FULL
             });
 
             this.setState({selectedFirearm: null, selectedAmmo: null});

--- a/src/sheet/templates/sheet/todo.html
+++ b/src/sheet/templates/sheet/todo.html
@@ -23,6 +23,9 @@
     + fix issue when adding a private sheet to sheet set
         + private sheets should be filtered out as choices to the sheet set
     + fix logout
+    - fix issue with adding CC weapons (name empty, "range too long")
+    - add button to shoot short bursts, sweeps
+    - assign arbitrary penalties
 
     + visual indication of damage taken, per hit location
     + concise view of current penalties, esp. in sheet set

--- a/tests/react/add-firearm-control.test.js
+++ b/tests/react/add-firearm-control.test.js
@@ -46,5 +46,6 @@ describe('AddFireArmControl',  function() {
         expect(spy).toHaveBeenCalled()
         expect(spy.mock.lastCall[0].ammo.id).toEqual(301)
         expect(spy.mock.lastCall[0].base.name).toEqual("Luger")
+        expect(spy.mock.lastCall[0].use_type).toEqual("FULL")
     });
 })

--- a/tests/react/stat-block-firearm-control.test.js
+++ b/tests/react/stat-block-firearm-control.test.js
@@ -96,7 +96,14 @@ describe('StatBlock -- FirearmControl', () => {
         await user.click(screen.getByRole("button", {name: "Add Firearm"}))
 
         expect(await screen.findByLabelText(/Firearm The Cannon/)).toBeInTheDocument()
+        expect(screen.getAllByLabelText(/Use type/)[1].textContent).toEqual("FULL")
     })
+
+    test.todo('verify that an existing firearm loaded from the sheet data behaves identically to one that has been just added')
+    test.todo('verify shoot button expends ammo')
+    test.todo('verify you can shoot a sweep')
+    test.todo('verify you can shoot a short burst')
+    test.todo('verify you can set the current ammo in a clip') // Add an edit control when hovering over clip data
 
     it('allows changing a firearm', async () => {
         const user = userEvent.setup()


### PR DESCRIPTION
A newly added firearm had a undefined `use_type` and suffered one-handed penalties as a result.